### PR TITLE
Show queue via !announce queue

### DIFF
--- a/plugins/Announcer/announcer.js
+++ b/plugins/Announcer/announcer.js
@@ -325,12 +325,17 @@ function execShow(cmdMessage) {
     .catch(logger.error);
     return;
   }
+  let current = new Date();
+  let lastHandle = new Date(announce.lastHandle);
+  let lastTry = new Date(announce.lastTry);
+  let lastHandleHumanized = moment.duration(current.getTime() - lastHandle.getTime()).humanize();
+  let lastTryHumanized = moment.duration(current.getTime() - lastTry.getTime()).humanize();
   var announce_print = "Announce: " + announce.name 
       + "\nInterval: " + announce.interval 
       + "\nChannel: <#" + announce.channel + ">" 
       + "\nStatus: " + (announce.active ? "ACTIVE" : "INACTIVE") + (announceRunners[announce.name] ? " [RUNNING]" : " [STOPPED]")
-      + "\nLast try: " + (announce.lastTry ? moment(announce.lastTry).format("DD.MM.YYYY HH:mm:ss") : "never")
-      + "\nLast handle: " + (announce.lastHandle ? moment(announce.lastHandle).format("DD.MM.YYYY HH:mm:ss") : "never")
+      + "\nLast try: " + (announce.lastTry ? moment(announce.lastTry).format("DD.MM.YYYY HH:mm:ss") + " (" + lastTryHumanized + " ago)" : "never")
+      + "\nLast handle: " + (announce.lastHandle ? moment(announce.lastHandle).format("DD.MM.YYYY HH:mm:ss") + " (" + lastHandleHumanized + " ago)" : "never")
       + "\nIn repeater queue: " + (repeater.isInQueue(announce.name) ? "yes" : "no")
       + "\nMessage: " + announce.message;
   cmdMessage.channel.send(announce_print)
@@ -352,6 +357,15 @@ function execEditmsg(cmdMessage) {
   announce.message = message;
   cmdMessage.channel.send(`Message of announce '${announce.name} has changed from "${oldMessage}" to "${announce.message}"`);
   logger.log("Message of announce '%s' has changed! User: %s Channel: #%s", announce.name, cmdMessage.caller.username, cmdMessage.channel.name);
+}
+
+function execQueue(cmdMessage) {
+  logger.info("Announces in queue: " + repeater.queue);
+  if (!repeater.queue.length) {
+    cmdMessage.channel.send("Nothing in repeater's queue!");
+    return;
+  }
+  cmdMessage.channel.send("Announces in repeater's queue: **" + repeater.queue.join(", ") + "**");
 }
 
 function createAnnounceCommand() {
@@ -381,6 +395,8 @@ function createAnnounceCommand() {
   announceCmd.createSubcommand("editmsg", execEditmsg)
     .setDescription("Edit a message of an announce")
     .setUsage("<announceName> <newMessage>");
+  announceCmd.createSubcommand("queue", execQueue)
+    .setDescription("Get announces in repeater's queue");
   return announceCmd;
 }
 

--- a/plugins/Announcer/repeater.js
+++ b/plugins/Announcer/repeater.js
@@ -11,7 +11,6 @@ class Repeater extends EventEmiter {
     this._options = options || {};
     this._logger = logger;
     this._queue = [];
-    this._inProcess = {};
     if (this.options.enabled) {
       this.announces = announces;
       this._logger.info("Repeater is ENABLED!");
@@ -69,7 +68,6 @@ class Repeater extends EventEmiter {
        }
       this.emit('process', announce, queue);
     });
-    this._inProcess[channel] = queue;
     setTimeout(_repeatAnnounce, durationParse(this.options.handleWait || "5m"), queue, this);
     this._logger.info("Repeater started! Announces in queue: ", queue.length);
     return queue;
@@ -89,10 +87,6 @@ class Repeater extends EventEmiter {
 
   get queue() {
     return this._queue;
-  }
-
-  get inProcess() {
-    return this._inProcess;
   }
 
 }


### PR DESCRIPTION
This PR add function for **show repeater's queue via command** to discord. 

![image](https://user-images.githubusercontent.com/4710267/32626537-e42b154c-c58f-11e7-8dec-ba07711348d3.png)

As second added additional info about lastHandle and lastTry of announce to show announce information -  **humanized durations (example: 5 minutes ago and etc)**

![image](https://user-images.githubusercontent.com/4710267/32626505-cee6cdd4-c58f-11e7-8a7f-3ab505ec8c04.png)